### PR TITLE
Bug fix issue 11

### DIFF
--- a/R/envDataLoad.R
+++ b/R/envDataLoad.R
@@ -55,9 +55,15 @@ envDataLoad <- function( filename = stop( "'filename' must be given!" ),
 		if( cont ){
 			class( env.data.col.wise ) <- get( ".class.data.env.cont",
 											   envir = .haplinMethEnv )
+			message( "Continuous data successfully loaded from '"
+			         , file.in.base
+			         , ".ffData/RData'")
 		} else {
 			class( env.data.col.wise ) <- get( ".class.data.env.cat",
 											   envir = .haplinMethEnv )
+			message( "Categorical data successfully loaded from '"
+			         , file.in.base
+			         , ".ffData/RData'")
 		}
 	} else {
 		warning( "Problem with the loaded data: 'cont' variable not found,

--- a/R/envDataLoad.R
+++ b/R/envDataLoad.R
@@ -25,7 +25,8 @@ envDataLoad <- function( filename = stop( "'filename' must be given!" ),
 	file.in.base <- paste( dir.in, "/", filename, "_env", sep = "" )
 	cont <- NULL
 	suppressWarnings( ff::ffload( file.in.base,
-								  rootpath = getOption( "fftempdir" ) ) )
+								  rootpath = getOption( "fftempdir" ),
+								  overwrite = TRUE ) )
 	loaded.objects <- ls( pattern = paste0( env.cols.name, ".[[:digit:]]" ) )
 
 	# maintain the correct order!

--- a/R/envDataSubset.R
+++ b/R/envDataSubset.R
@@ -175,8 +175,8 @@ envDataSubset <- function(env.data = stop("You need to specify the data!",
 	new.rownames <- c()
 
 	# create new ff object, with the new dimensions
-	cont.data <- "env.cont" %in% info.env.data$class
-	if(!cont.data){
+	cont <- "env.cont" %in% info.env.data$class
+	if(!cont){
 		data.out <- ff::ff(NA,
 							levels = levels(env.data[[ 1 ]]),
 							dim = new.dim,
@@ -211,7 +211,7 @@ envDataSubset <- function(env.data = stop("You need to specify the data!",
 	if(is.subset.rows){
 		data.out <- lapply(env.data.col.wise, function(x){
 			sub <- x[ final.row.sel, ]
-			if(!cont.data){
+			if(!cont){
 				out <- ff::ff(sub, levels = ff::levels.ff(sub),
 							   dim = dim(sub),
 							   vmode = ff::vmode(x))
@@ -239,7 +239,7 @@ envDataSubset <- function(env.data = stop("You need to specify the data!",
 		assign(cur.name, env.data.col.wise[[i]])
 		cur.names <- c(cur.names, cur.name)
 	}
-	save.list <- c(cur.names, "cont.data")
+	save.list <- c(cur.names, "cont")
 	ff::ffsave(list = save.list,
 				file = file.path(dir.out, files.list$file.out.base))
 	cat("... saved to files: ", files.list$file.out.ff, ", ",

--- a/R/envDataSubset.R
+++ b/R/envDataSubset.R
@@ -239,7 +239,7 @@ envDataSubset <- function(env.data = stop("You need to specify the data!",
 		assign(cur.name, env.data.col.wise[[i]])
 		cur.names <- c(cur.names, cur.name)
 	}
-	save.list <- c(cur.names, "cont.data")
+	save.list <- c(cur.names, "cont")
 	ff::ffsave(list = save.list,
 				file = file.path(dir.out, files.list$file.out.base))
 	cat("... saved to files: ", files.list$file.out.ff, ", ",


### PR DESCRIPTION
Fixing bug (#11) that resulted in `envDataLoad()` producing the warning `" Problem with the loaded data: 'cont' variable not found, assuming that the data is continuous"`, regardless of whether the data being loaded was coded as continuous or not.  