### PR TITLE
Fix bug #24

### DIFF
--- a/R/envDataSubset.R
+++ b/R/envDataSubset.R
@@ -203,7 +203,7 @@ envDataSubset <- function(env.data = stop("You need to specify the data!",
 	# if subsetting rows
 	if(is.subset.rows){
 		data.out <- lapply(env.data.col.wise, function(x){
-			sub <- x[ final.row.sel, ]
+			sub <- x[ final.row.sel, , drop = FALSE ]
 			if(!cont){
 				out <- ff::ff(sub, levels = ff::levels.ff(sub),
 							   dim = dim(sub),


### PR DESCRIPTION
I implemented the fix that I suggested in issue https://github.com/jromanowska/HaplinMethyl/issues/24 by adding ` , drop = FALSE` to line 206 (where the subsetting of the data by row takes place). The `envDataSubset` function is now able to successfully extract a single row. 

I tested it using the test data (`env_data_test.dat`), as well as real DNAm data on SAFE. Specifying `row.names` equal to a vector containing one row name works as expected. Specifying `row.ids` equal to a single integer works as expected. 